### PR TITLE
Add support for zero limit which blocks requests

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
@@ -76,6 +76,19 @@ namespace AspNetCoreRateLimit
                         return;
                     }
                 }
+                // if limit is zero or less, block the request.
+                else
+                {
+                    // process request count
+                    var counter = _processor.ProcessRequest(identity, rule);
+
+                    // log blocked request
+                    LogBlockedRequest(httpContext, identity, counter, rule);
+
+                    // break execution (Int32 max used to represent infinity)
+                    await ReturnQuotaExceededResponse(httpContext, rule, Int32.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    return;
+                }
             }
 
             //set X-Rate-Limit headers for the longest period

--- a/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
@@ -80,6 +80,19 @@ namespace AspNetCoreRateLimit
                         return;
                     }
                 }
+                // if limit is zero or less, block the request.
+                else
+                {
+                    // process request count
+                    var counter = _processor.ProcessRequest(identity, rule);
+
+                    // log blocked request
+                    LogBlockedRequest(httpContext, identity, counter, rule);
+
+                    // break execution (Int32 max used to represent infinity)
+                    await ReturnQuotaExceededResponse(httpContext, rule, Int32.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    return;
+                }
             }
 
             //set X-Rate-Limit headers for the longest period

--- a/test/AspNetCoreRateLimit.Tests/ClientRateLimitTests.cs
+++ b/test/AspNetCoreRateLimit.Tests/ClientRateLimitTests.cs
@@ -123,6 +123,31 @@ namespace AspNetCoreRateLimit.Tests
         }
 
         [Fact]
+        public async Task OverrideGeneralRuleAsLimitZero()
+        {
+            // Arrange
+            var clientId = "cl-key-2";
+            int responseStatusCode = 0;
+
+
+            // Act    
+            for (int i = 0; i < 4; i++)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, apiPath);
+                request.Headers.Add("X-ClientId", clientId);
+                request.Headers.Add("X-Real-IP", ip);
+
+                var response = await Client.SendAsync(request);
+                responseStatusCode = (int)response.StatusCode;
+            }
+
+            // Assert
+            Assert.Equal(429, responseStatusCode);
+
+        }
+
+
+        [Fact]
         public async Task WhitelistPath()
         {
             // Arrange

--- a/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
+++ b/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
@@ -67,6 +67,28 @@ namespace AspNetCoreRateLimit.Tests
         }
 
         [Fact]
+        public async Task GlobalIpLimitZeroRule()
+        {
+            // Arrange
+            var ip = "84.247.85.231";
+
+            int responseStatusCode = 0;
+
+            // Act    
+            for (int i = 0; i < 4; i++)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, apiValuesPath);
+                request.Headers.Add("X-Real-IP", ip);
+
+                var response = await Client.SendAsync(request);
+                responseStatusCode = (int)response.StatusCode;
+            }
+
+            // Assert
+            Assert.Equal(429, responseStatusCode);
+        }
+
+        [Fact]
         public async Task WhitelistIp()
         {
             // Arrange

--- a/test/AspNetCoreRateLimit.Tests/appsettings.json
+++ b/test/AspNetCoreRateLimit.Tests/appsettings.json
@@ -92,6 +92,16 @@
             "Limit": 2
           }
         ]
+      },
+      {
+        "Ip": "84.247.85.231",
+        "Rules": [
+          {
+            "Endpoint": "*",
+            "Period": "1m",
+            "Limit": 0
+          }
+        ]
       }
     ]
   },
@@ -150,6 +160,11 @@
             "Endpoint": "*",
             "Period": "1s",
             "Limit": 10
+          },
+          {
+            "Endpoint": "get:/api/clients",
+            "Period": "1m",
+            "Limit": 0
           },
           {
             "Endpoint": "post:/api/clients",


### PR DESCRIPTION
I had originally pulled down this package with the intent that I could not only throttle, but also block requests that might not be from a specific IP or client. Not sure if you're looking to support this workflow within the project, but figured I'd make a pull request and ask.