### PR TITLE
Add support for multiple counter key building strategies

### DIFF
--- a/src/AspNetCoreRateLimit/Core/Counter/ClientIdLimitingCounterKeyBuilder.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/ClientIdLimitingCounterKeyBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace AspNetCoreRateLimit.Core.Counter
+{
+    public class ClientIdLimitingCounterKeyBuilder : IBuildCounterKey
+    {
+        private readonly RateLimitCoreOptions _options;
+
+        public ClientIdLimitingCounterKeyBuilder(RateLimitCoreOptions options)
+        {
+            _options = options;
+        }
+        
+        public string BuildCounterKey(ClientRequestIdentity requestIdentity, RateLimitRule rule)
+        {
+            return $"{_options.RateLimitCounterPrefix}_{requestIdentity.ClientId}_{rule.Period}";
+        }
+    }
+}

--- a/src/AspNetCoreRateLimit/Core/Counter/CounterKeyBuilderFactory.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/CounterKeyBuilderFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using AspNetCoreRateLimit.Core.Counter;
+
+namespace AspNetCoreRateLimit
+{
+    public class CounterKeyBuilderFactory : ICreateCounterKey
+    {
+        public IBuildCounterKey Create(bool ipRateLimiting, RateLimitCoreOptions options)
+        {
+            IBuildCounterKey builder = null;
+
+            if (ipRateLimiting)
+            {
+                builder = new IpRateLimitingCounterKeyBuilder(options);
+            }
+            else
+            {
+                builder = new ClientIdLimitingCounterKeyBuilder(options);
+            }
+
+
+            if (options.EnableEndpointRateLimiting)
+            {
+                if (options.CounterKeyBuilder.Equals("endpoint", StringComparison.OrdinalIgnoreCase))
+                {
+                    builder = new EndpointRuleBasedCounterKeyBuilder(builder);
+                }
+                else
+                {
+                    builder = new RequestIdentityBasedCounterKeyBuilder(builder);
+                }
+            }
+
+
+
+            return builder;
+        }
+    }
+}

--- a/src/AspNetCoreRateLimit/Core/Counter/EndpointRuleBasedCounterKeyBuilder.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/EndpointRuleBasedCounterKeyBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace AspNetCoreRateLimit
+{
+    public class EndpointRuleBasedCounterKeyBuilder : IBuildCounterKey
+    {
+        private readonly IBuildCounterKey _innerBuilder;
+
+        public EndpointRuleBasedCounterKeyBuilder(IBuildCounterKey innerBuilder)
+        {
+            _innerBuilder = innerBuilder;
+        }
+        
+        public string BuildCounterKey(ClientRequestIdentity requestIdentity, RateLimitRule rule)
+        {
+            string baseKey = _innerBuilder.BuildCounterKey(requestIdentity, rule);
+            
+            return $"{baseKey}_{rule.Endpoint}";
+        }
+    }
+}

--- a/src/AspNetCoreRateLimit/Core/Counter/IBuildCounterKey.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/IBuildCounterKey.cs
@@ -1,0 +1,7 @@
+﻿namespace AspNetCoreRateLimit
+{
+    public interface IBuildCounterKey
+    {
+        string BuildCounterKey(ClientRequestIdentity requestIdentity, RateLimitRule rule);
+    }
+}

--- a/src/AspNetCoreRateLimit/Core/Counter/ICreateCounterKey.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/ICreateCounterKey.cs
@@ -1,0 +1,7 @@
+﻿namespace AspNetCoreRateLimit.Core.Counter
+{
+    public interface ICreateCounterKey
+    {
+        IBuildCounterKey Create(bool ipRateLimiting, RateLimitCoreOptions options);
+    }
+}

--- a/src/AspNetCoreRateLimit/Core/Counter/IpRateLimitingCounterKeyBuilder.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/IpRateLimitingCounterKeyBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace AspNetCoreRateLimit.Core.Counter
+{
+    public class IpRateLimitingCounterKeyBuilder : IBuildCounterKey
+    {
+        private readonly RateLimitCoreOptions _options;
+
+        public IpRateLimitingCounterKeyBuilder(RateLimitCoreOptions options)
+        {
+            _options = options;
+        }
+        
+        public string BuildCounterKey(ClientRequestIdentity requestIdentity, RateLimitRule rule)
+        {
+            return $"{_options.RateLimitCounterPrefix}_{requestIdentity.ClientIp}_{rule.Period}";
+        }
+    }
+}

--- a/src/AspNetCoreRateLimit/Core/Counter/RequestIdentityBasedCounterKeyBuilder.cs
+++ b/src/AspNetCoreRateLimit/Core/Counter/RequestIdentityBasedCounterKeyBuilder.cs
@@ -1,0 +1,19 @@
+﻿namespace AspNetCoreRateLimit
+{
+    public class RequestIdentityBasedCounterKeyBuilder : IBuildCounterKey
+    {
+        private readonly IBuildCounterKey _innerBuilder;
+
+        public RequestIdentityBasedCounterKeyBuilder(IBuildCounterKey innerBuilder)
+        {
+            _innerBuilder = innerBuilder;
+        }
+        
+        public string BuildCounterKey(ClientRequestIdentity requestIdentity, RateLimitRule rule)
+        {
+            string baseKey = _innerBuilder.BuildCounterKey(requestIdentity, rule);
+            
+            return $"{baseKey}_{requestIdentity.HttpVerb}_{requestIdentity.Path}";
+        }
+    }
+}

--- a/src/AspNetCoreRateLimit/Models/RateLimitCoreOptions.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitCoreOptions.cs
@@ -26,6 +26,11 @@ namespace AspNetCoreRateLimit
         /// Gets or sets the counter prefix, used to compose the rate limit counter cache key
         /// </summary>
         public string RateLimitCounterPrefix { get; set; } = "crlc";
+        
+        /// <summary>
+        /// Gets or sets the counter key builder strategy, by default value is set to RequestIdentity 
+        /// </summary>
+        public string CounterKeyBuilder { get; set; } = "RequestIdentity";
 
         /// <summary>
         /// Gets or sets a value indicating whether all requests, including the rejected ones, should be stacked in this order: day, hour, min, sec

--- a/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
+++ b/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
@@ -5,16 +5,19 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AspNetCoreRateLimit.Tests
 {
     public class IpRateLimitTests: IClassFixture<RateLimitFixture<Demo.Startup>>
     {
+        private readonly ITestOutputHelper _output;
         private const string apiValuesPath = "/api/values";
         private const string apiRateLimitPath = "/api/ipratelimit";
 
-        public IpRateLimitTests(RateLimitFixture<Demo.Startup> fixture)
+        public IpRateLimitTests(RateLimitFixture<Demo.Startup> fixture, ITestOutputHelper output)
         {
+            _output = output;
             Client = fixture.Client;
         }
 
@@ -129,6 +132,7 @@ namespace AspNetCoreRateLimit.Tests
 
                 var response = await Client.SendAsync(request);
                 responseStatusCode = (int)response.StatusCode;
+                _output.WriteLine($"{verb}{apiValuesPath} attempt {i} results with {(int)response.StatusCode}");
             }
 
             // Assert


### PR DESCRIPTION
This PR introduces opportunity to change the way of how counter key is constructed. Considering TODO from RateLimitCore class this should allow to rate limit /api/values/1 and api/values/2 under same counter and resolves problem described in #41 