### PR TITLE
Breaking Change: Abstract away the concept of a clientId in the Client Ratelimiter

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/MiddlewareExtensions.cs
+++ b/src/AspNetCoreRateLimit/Middleware/MiddlewareExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using AspNetCoreRateLimit.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace AspNetCoreRateLimit
 {
@@ -14,6 +17,9 @@ namespace AspNetCoreRateLimit
             return builder.UseMiddleware<ClientRateLimitMiddleware>();
         }
 
-       
+        public static void AddHeaderClientRequestStore(this IServiceCollection services)
+        {
+            services.TryAddSingleton<IClientRequestStore, HeaderClientRequestStore>();
+        }
     }
 }

--- a/src/AspNetCoreRateLimit/Services/HeaderClientRequestStore.cs
+++ b/src/AspNetCoreRateLimit/Services/HeaderClientRequestStore.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCoreRateLimit.Services
+{
+    public class HeaderClientRequestStore : IClientRequestStore
+    {
+        private ClientRateLimitOptions _options;
+
+        public HeaderClientRequestStore(IOptions<ClientRateLimitOptions> options)
+        {
+            _options = options.Value;
+        }
+        public async Task<ClientRequestIdentity> GetClientRequestIdentityAsync(HttpContext httpContext)
+        {
+            var clientId = "anon";
+            if (httpContext.Request.Headers.Keys.Contains(_options.ClientIdHeader, StringComparer.CurrentCultureIgnoreCase))
+            {
+                clientId = httpContext.Request.Headers[_options.ClientIdHeader].First();
+            }
+
+            return new ClientRequestIdentity
+            {
+                Path = httpContext.Request.Path.ToString().ToLowerInvariant(),
+                HttpVerb = httpContext.Request.Method.ToLowerInvariant(),
+                ClientId = clientId
+            };
+        }
+    }
+}

--- a/src/AspNetCoreRateLimit/Services/IClientRequestStore.cs
+++ b/src/AspNetCoreRateLimit/Services/IClientRequestStore.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNetCoreRateLimit.Services
+{
+    public interface IClientRequestStore
+    {
+        Task<ClientRequestIdentity> GetClientRequestIdentityAsync(HttpContext context);
+    }
+}

--- a/test/AspNetCoreRateLimit.Demo/Startup.cs
+++ b/test/AspNetCoreRateLimit.Demo/Startup.cs
@@ -33,6 +33,7 @@ namespace AspNetCoreRateLimit.Demo
             services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
 
             //configure client rate limiting middleware
+            services.AddHeaderClientRequestStore(); // pulls the client_id from the header
             services.Configure<ClientRateLimitOptions>(Configuration.GetSection("ClientRateLimiting"));
             services.Configure<ClientRateLimitPolicies>(Configuration.GetSection("ClientRateLimitPolicies"));
             services.AddSingleton<IClientPolicyStore, MemoryCacheClientPolicyStore>();


### PR DESCRIPTION
https://github.com/stefanprodan/AspNetCoreRateLimit/issues/54

End users will need to select what type of IClientRequestStore implementation they want.

AspNetCoreRateLimit supplies an example that pulls the client from the header.
Other implementations can come externally where a client_id can be anything.

To fix the break, you need to add the following to your Startup.cs, if you want the original client_id fetcher that came with AspNetCoreRateLimit

services.AddHeaderClientRequestStore(); // pulls the client_id from the header