### PR TITLE
RateLimitProcessor was ignoring GeneralRules when policies were null

### DIFF
--- a/src/AspNetCoreRateLimit/Core/ClientRateLimitProcessor.cs
+++ b/src/AspNetCoreRateLimit/Core/ClientRateLimitProcessor.cs
@@ -25,12 +25,12 @@ namespace AspNetCoreRateLimit
         {
             var policy = await _policyStore.GetAsync($"{_options.ClientPolicyPrefix}_{identity.ClientId}", cancellationToken);
 
+            var limits = new List<RateLimitRule>();
             if (policy != null)
             {
-                return GetMatchingRules(identity, policy.Rules);
+                AddLimitsFromRules(identity, policy.Rules, limits);
             }
-
-            return Enumerable.Empty<RateLimitRule>();
+            return GetMatchingRules(identity, limits);
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Core/IpRateLimitProcessor.cs
+++ b/src/AspNetCoreRateLimit/Core/IpRateLimitProcessor.cs
@@ -37,10 +37,10 @@ namespace AspNetCoreRateLimit
                     rules.AddRange(item.Rules);
                 }
 
-                return GetMatchingRules(identity, rules);
+                AddLimitsFromRules(identity, rules, limits);
             }
 
-            return Enumerable.Empty<RateLimitRule>();
+            return GetMatchingRules(identity, limits);
         }
 
         public override bool IsWhitelisted(ClientRequestIdentity requestIdentity)

--- a/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
+++ b/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
@@ -194,7 +194,7 @@ namespace AspNetCoreRateLimit
             return limits;
         }
 
-        public virtual void AddLimitsFromRules(ClientRequestIdentity identity, List<RateLimitRule> rules, List<RateLimitRule> limits)
+        protected virtual void AddLimitsFromRules(ClientRequestIdentity identity, List<RateLimitRule> rules, List<RateLimitRule> limits)
         {
             if (_options.EnableEndpointRateLimiting)
             {


### PR DESCRIPTION
After upgrading from 2.1.0 to 3.0.1, RateLimitProcessor can no longer handle GeneralRules.

This is due to the refactoring bug.
In ClientRateLimitProcessor.cs from line [32 ](https://github.com/stefanprodan/AspNetCoreRateLimit/commit/4cdcd95afed68f1fbc1eea0e0dd8b88b2c717d92#diff-6b666f1ab2dd5c14079f88acc45dbb0cL32) to line [96](https://github.com/stefanprodan/AspNetCoreRateLimit/commit/4cdcd95afed68f1fbc1eea0e0dd8b88b2c717d92#diff-6b666f1ab2dd5c14079f88acc45dbb0cL96) code was deleted and moved to RateLimitProcessor.cs, but if you take a look carefully, code from line [51](https://github.com/stefanprodan/AspNetCoreRateLimit/commit/4cdcd95afed68f1fbc1eea0e0dd8b88b2c717d92#diff-6b666f1ab2dd5c14079f88acc45dbb0cL51) is outside of _if (policy != null)_ scope (line [30](https://github.com/stefanprodan/AspNetCoreRateLimit/commit/4cdcd95afed68f1fbc1eea0e0dd8b88b2c717d92#diff-6b666f1ab2dd5c14079f88acc45dbb0cL30)). After refactoring, it was actually moved inside that scope. So if [this condition](https://github.com/stefanprodan/AspNetCoreRateLimit/blob/master/src/AspNetCoreRateLimit/Core/IpRateLimitProcessor.cs#L29) is false, GeneralRules are ignored.

This PR fixes the issue.
