### PR TITLE
Change the counter's type to double

### DIFF
--- a/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
+++ b/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
@@ -61,7 +61,7 @@ namespace AspNetCoreRateLimit
             // serial reads and writes on same key
             using (await AsyncLock.WriterLockAsync(counterId).ConfigureAwait(false))
             {
-                var entry = await _counterStore.GetAsync(conuterId, cancellationToken);
+                var entry = await _counterStore.GetAsync(counterId, cancellationToken);
 
                 if (entry.HasValue)
                 {

--- a/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
+++ b/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
@@ -57,11 +57,11 @@ namespace AspNetCoreRateLimit
             };
 
             var counterId = BuildCounterKey(requestIdentity, rule);
-
+            var accountId = requestIdentity.accountId;
             // serial reads and writes on same key
-            using (await AsyncLock.WriterLockAsync(counterId).ConfigureAwait(false))
+            using (await AsyncLock.WriterLockAsync(accountId).ConfigureAwait(false))
             {
-                var entry = await _counterStore.GetAsync(counterId, cancellationToken);
+                var entry = await _counterStore.GetAsync(accountId, cancellationToken);
 
                 if (entry.HasValue)
                 {
@@ -81,7 +81,7 @@ namespace AspNetCoreRateLimit
                 }
 
                 // stores: id (string) - timestamp (datetime) - total_requests (long)
-                await _counterStore.SetAsync(counterId, counter, rule.PeriodTimespan.Value, cancellationToken);
+                await _counterStore.SetAsync(accountId, counter, rule.PeriodTimespan.Value, cancellationToken);
             }
 
             return counter;
@@ -91,7 +91,7 @@ namespace AspNetCoreRateLimit
         {
             var headers = new RateLimitHeaders();
 
-            long remaining;
+            double remaining;
             DateTime reset;
 
             if (counter.HasValue)

--- a/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
+++ b/src/AspNetCoreRateLimit/Core/RateLimitProcessor.cs
@@ -57,11 +57,11 @@ namespace AspNetCoreRateLimit
             };
 
             var counterId = BuildCounterKey(requestIdentity, rule);
-            var accountId = requestIdentity.accountId;
+
             // serial reads and writes on same key
-            using (await AsyncLock.WriterLockAsync(accountId).ConfigureAwait(false))
+            using (await AsyncLock.WriterLockAsync(counterId).ConfigureAwait(false))
             {
-                var entry = await _counterStore.GetAsync(accountId, cancellationToken);
+                var entry = await _counterStore.GetAsync(conuterId, cancellationToken);
 
                 if (entry.HasValue)
                 {
@@ -81,7 +81,7 @@ namespace AspNetCoreRateLimit
                 }
 
                 // stores: id (string) - timestamp (datetime) - total_requests (long)
-                await _counterStore.SetAsync(accountId, counter, rule.PeriodTimespan.Value, cancellationToken);
+                await _counterStore.SetAsync(counterId, counter, rule.PeriodTimespan.Value, cancellationToken);
             }
 
             return counter;

--- a/src/AspNetCoreRateLimit/Middleware/IRateLimitConfiguration.cs
+++ b/src/AspNetCoreRateLimit/Middleware/IRateLimitConfiguration.cs
@@ -11,6 +11,6 @@ namespace AspNetCoreRateLimit
 
         ICounterKeyBuilder EndpointCounterKeyBuilder { get; }
 
-        Func<long> RateIncrementer { get; }
+        Func<double> RateIncrementer { get; }
     }
 }

--- a/src/AspNetCoreRateLimit/Middleware/RateLimitConfiguration.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitConfiguration.cs
@@ -12,7 +12,7 @@ namespace AspNetCoreRateLimit
 
         public virtual ICounterKeyBuilder EndpointCounterKeyBuilder { get; } = new PathCounterKeyBuilder();
 
-        public virtual Func<long> RateIncrementer { get; } = () => 1;
+        public virtual Func<double> RateIncrementer { get; } = () => 1;
 
         public RateLimitConfiguration(
             IHttpContextAccessor httpContextAccessor,

--- a/src/AspNetCoreRateLimit/Models/RateLimitCounter.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitCounter.cs
@@ -9,6 +9,6 @@ namespace AspNetCoreRateLimit
     {
         public DateTime Timestamp { get; set; }
 
-        public long Count { get; set; }
+        public double Count { get; set; }
     }
 }

--- a/src/AspNetCoreRateLimit/Models/RateLimitRule.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitRule.cs
@@ -24,6 +24,6 @@ namespace AspNetCoreRateLimit
         /// <summary>
         /// Maximum number of requests that a client can make in a defined period
         /// </summary>
-        public long Limit { get; set; }
+        public double Limit { get; set; }
     }
 }


### PR DESCRIPTION
Changes for Ratelimit as per metadata parsing.
changes the type to double instead of long as per incoming data type.