### PR TITLE
Depedency Clean-up in csproj

### DIFF
--- a/src/AspNetCoreRateLimit/AspNetCoreRateLimit.csproj
+++ b/src/AspNetCoreRateLimit/AspNetCoreRateLimit.csproj
@@ -16,10 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+	<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+	<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+	<PackageReference Include="Microsoft.Extensions.Options" Version="3.1.6" />
+	<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I saw that there are some depedency import which can be simplified. The idea is to have the absolute minimum of external nugets referenced here (e.g. use Microsoft.Extensions.Loggging.Abstractions instead of Microsoft.Extensions.Logging as we only use abstractions in this library).

* Use Abstraction nuget where available (Http+Logging)
* Use Microsoft.Extensions.Options instead of indirect dependency from Microsoft.Extensions.Logging