### PR TITLE
Return null as default client id instead of "anon"

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
@@ -51,7 +51,7 @@ namespace AspNetCoreRateLimit
 
             foreach (var rule in rules)
             {
-                // increment counter		
+                // increment counter
                 var rateLimitCounter = await _processor.ProcessRequestAsync(identity, rule, context.RequestAborted);
 
                 if (rule.Limit > 0)
@@ -152,7 +152,7 @@ namespace AspNetCoreRateLimit
                 ClientIp = clientIp,
                 Path = httpContext.Request.Path.ToString().ToLowerInvariant(),
                 HttpVerb = httpContext.Request.Method.ToLowerInvariant(),
-                ClientId = clientId
+                ClientId = clientId ?? "anon"
             };
         }
 

--- a/src/AspNetCoreRateLimit/Resolvers/ClientHeaderResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/ClientHeaderResolveContributor.cs
@@ -17,7 +17,7 @@ namespace AspNetCoreRateLimit
         }
         public string ResolveClient()
         {
-            var clientId = "anon";
+            string clientId = null;
             var httpContext = _httpContextAccessor.HttpContext;
 
             if (httpContext.Request.Headers.TryGetValue(_headerName, out var values))


### PR DESCRIPTION
Nulls are handled by RateLimitMiddleware.ResolveIdentity when iterating
over client resolvers to find a match, while "anon" was treated as a
valid id and thus causing the iteration to stop and custom resolvers to
never be called.

This should not modify behavior as "anon" is still returned as default
client id if no resolvers have a match.

Fixes #146