### PR TITLE
Remove unnecessary dependency on the IHttpContextAccessor

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/RateLimitConfiguration.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitConfiguration.cs
@@ -15,18 +15,15 @@ namespace AspNetCoreRateLimit
         public virtual Func<double> RateIncrementer { get; } = () => 1;
 
         public RateLimitConfiguration(
-            IHttpContextAccessor httpContextAccessor,
             IOptions<IpRateLimitOptions> ipOptions,
             IOptions<ClientRateLimitOptions> clientOptions)
         {
             IpRateLimitOptions = ipOptions?.Value;
             ClientRateLimitOptions = clientOptions?.Value;
-            HttpContextAccessor = httpContextAccessor;
         }
 
         protected readonly IpRateLimitOptions IpRateLimitOptions;
         protected readonly ClientRateLimitOptions ClientRateLimitOptions;
-        protected readonly IHttpContextAccessor HttpContextAccessor;
 
         public virtual void RegisterResolvers()
         {
@@ -35,16 +32,16 @@ namespace AspNetCoreRateLimit
 
             if (clientIdHeader != null)
             {
-                ClientResolvers.Add(new ClientHeaderResolveContributor(HttpContextAccessor, clientIdHeader));
+                ClientResolvers.Add(new ClientHeaderResolveContributor(clientIdHeader));
             }
 
             // the contributors are resolved in the order of their collection index
             if (realIpHeader != null)
             {
-                IpResolvers.Add(new IpHeaderResolveContributor(HttpContextAccessor, realIpHeader));
+                IpResolvers.Add(new IpHeaderResolveContributor(realIpHeader));
             }
 
-            IpResolvers.Add(new IpConnectionResolveContributor(HttpContextAccessor));
+            IpResolvers.Add(new IpConnectionResolveContributor());
         }
 
         protected string GetClientIdHeader()

--- a/src/AspNetCoreRateLimit/Middleware/RateLimitConfiguration.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitConfiguration.cs
@@ -30,18 +30,31 @@ namespace AspNetCoreRateLimit
 
         public virtual void RegisterResolvers()
         {
-            if (!string.IsNullOrEmpty(ClientRateLimitOptions?.ClientIdHeader) || !string.IsNullOrEmpty(IpRateLimitOptions?.ClientIdHeader))
+            string clientIdHeader = GetClientIdHeader();
+            string realIpHeader = GetRealIp();
+
+            if (clientIdHeader != null)
             {
-                ClientResolvers.Add(new ClientHeaderResolveContributor(HttpContextAccessor, ClientRateLimitOptions.ClientIdHeader));
+                ClientResolvers.Add(new ClientHeaderResolveContributor(HttpContextAccessor, clientIdHeader));
             }
 
             // the contributors are resolved in the order of their collection index
-            if (!string.IsNullOrEmpty(ClientRateLimitOptions?.RealIpHeader) || !string.IsNullOrEmpty(IpRateLimitOptions?.RealIpHeader))
+            if (realIpHeader != null)
             {
-                IpResolvers.Add(new IpHeaderResolveContributor(HttpContextAccessor, IpRateLimitOptions.RealIpHeader));
+                IpResolvers.Add(new IpHeaderResolveContributor(HttpContextAccessor, realIpHeader));
             }
 
             IpResolvers.Add(new IpConnectionResolveContributor(HttpContextAccessor));
+        }
+
+        protected string GetClientIdHeader()
+        {
+            return ClientRateLimitOptions?.ClientIdHeader ?? IpRateLimitOptions?.ClientIdHeader;
+        }
+
+        protected string GetRealIp()
+        {
+            return IpRateLimitOptions?.RealIpHeader ?? ClientRateLimitOptions?.RealIpHeader;
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
@@ -126,7 +126,7 @@ namespace AspNetCoreRateLimit
             {
                 foreach (var resolver in _config.ClientResolvers)
                 {
-                    clientId = await resolver.ResolveClientAsync();
+                    clientId = await resolver.ResolveClientAsync(httpContext);
 
                     if (!string.IsNullOrEmpty(clientId))
                     {
@@ -139,7 +139,7 @@ namespace AspNetCoreRateLimit
             {
                 foreach (var resolver in _config.IpResolvers)
                 {
-                    clientIp = resolver.ResolveIp();
+                    clientIp = resolver.ResolveIp(httpContext);
 
                     if (!string.IsNullOrEmpty(clientIp))
                     {

--- a/src/AspNetCoreRateLimit/Resolvers/ClientHeaderResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/ClientHeaderResolveContributor.cs
@@ -6,20 +6,15 @@ namespace AspNetCoreRateLimit
 {
     public class ClientHeaderResolveContributor : IClientResolveContributor
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly string _headerName;
 
-        public ClientHeaderResolveContributor(
-            IHttpContextAccessor httpContextAccessor,
-            string headerName)
+        public ClientHeaderResolveContributor(string headerName)
         {
-            _httpContextAccessor = httpContextAccessor;
             _headerName = headerName;
         }
-        public Task<string> ResolveClientAsync()
+        public Task<string> ResolveClientAsync(HttpContext httpContext)
         {
             string clientId = null;
-            var httpContext = _httpContextAccessor.HttpContext;
 
             if (httpContext.Request.Headers.TryGetValue(_headerName, out var values))
             {

--- a/src/AspNetCoreRateLimit/Resolvers/IClientResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/IClientResolveContributor.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 
 namespace AspNetCoreRateLimit
 {
     public interface IClientResolveContributor
     {
-        Task<string> ResolveClientAsync();
+        Task<string> ResolveClientAsync(HttpContext httpContext);
     }
 }

--- a/src/AspNetCoreRateLimit/Resolvers/IIpResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/IIpResolveContributor.cs
@@ -1,7 +1,9 @@
-﻿namespace AspNetCoreRateLimit
+﻿using Microsoft.AspNetCore.Http;
+
+namespace AspNetCoreRateLimit
 {
     public interface IIpResolveContributor
     {
-        string ResolveIp();
+        string ResolveIp(HttpContext httpContext);
     }
 }

--- a/src/AspNetCoreRateLimit/Resolvers/IpConnectionResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/IpConnectionResolveContributor.cs
@@ -4,16 +4,15 @@ namespace AspNetCoreRateLimit
 {
     public class IpConnectionResolveContributor : IIpResolveContributor
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public IpConnectionResolveContributor(IHttpContextAccessor httpContextAccessor)
+        public IpConnectionResolveContributor()
         {
-            _httpContextAccessor = httpContextAccessor;
+            // no op
         }
 
-        public string ResolveIp()
+        public string ResolveIp(HttpContext httpContext)
         {
-            return _httpContextAccessor.HttpContext.Connection.RemoteIpAddress?.ToString();
+            return httpContext.Connection.RemoteIpAddress?.ToString();
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Resolvers/IpConnectionResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/IpConnectionResolveContributor.cs
@@ -7,7 +7,7 @@ namespace AspNetCoreRateLimit
 
         public IpConnectionResolveContributor()
         {
-            // no op
+
         }
 
         public string ResolveIp(HttpContext httpContext)

--- a/src/AspNetCoreRateLimit/Resolvers/IpHeaderResolveContributor.cs
+++ b/src/AspNetCoreRateLimit/Resolvers/IpHeaderResolveContributor.cs
@@ -6,24 +6,19 @@ namespace AspNetCoreRateLimit
 {
     public class IpHeaderResolveContributor : IIpResolveContributor
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly string _headerName;
 
         public IpHeaderResolveContributor(
-            IHttpContextAccessor httpContextAccessor,
             string headerName)
         {
-            _httpContextAccessor = httpContextAccessor;
             _headerName = headerName;
         }
 
-        public string ResolveIp()
+        public string ResolveIp(HttpContext httpContext)
         {
             IPAddress clientIp = null;
 
-            var httpContent = _httpContextAccessor.HttpContext;
-
-            if (httpContent.Request.Headers.TryGetValue(_headerName, out var values))
+            if (httpContext.Request.Headers.TryGetValue(_headerName, out var values))
             {
                 clientIp = IpAddressUtil.ParseIp(values.Last());
             }

--- a/test/AspNetCoreRateLimit.Demo/Startup.cs
+++ b/test/AspNetCoreRateLimit.Demo/Startup.cs
@@ -44,10 +44,6 @@ namespace AspNetCoreRateLimit.Demo
 
             }).AddNewtonsoftJson();
 
-            // https://github.com/aspnet/Hosting/issues/793
-            // the IHttpContextAccessor service is not registered by default.
-            // the clientId/clientIp resolvers use it.
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             // configure the resolvers
             services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();


### PR DESCRIPTION
Because the IClientResolveContributor and IIpResolveContributor are both called in a method RateLimitMiddleware.ResolveIdentityAsync(HttpContext httpContext) that has access to the current HttpContext, the need can be fulfilled by passing it as a parameter to the IClientResolveContributor.ResolveClientAsync() and IIpResolveContributor.ResolveIp() methods.

This approach also prevents any potential performance or usage mistakes of using IHttpContextAccessor or the caching of HttpContext that may find its way into the code base in later iterations. Since HttpContext will never be used in any other capacity in ClientHeaderResolveContributor or IpConnectionResolveContributor (or subsequent implementations), this implementation limits the misuse of HttpContext.