### PR TITLE
Added MonitorMode option to the rate limit rules

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
@@ -22,7 +22,7 @@ namespace AspNetCoreRateLimit
 
         protected override void LogBlockedRequest(HttpContext httpContext, ClientRequestIdentity identity, RateLimitCounter counter, RateLimitRule rule)
         {
-            _logger.LogInformation($"Request {identity.HttpVerb}:{identity.Path} from ClientId {identity.ClientId} has been blocked, quota {rule.Limit}/{rule.Period} exceeded by {counter.Count - rule.Limit}. Blocked by rule {rule.Endpoint}, TraceIdentifier {httpContext.TraceIdentifier}.");
+            _logger.LogInformation($"Request {identity.HttpVerb}:{identity.Path} from ClientId {identity.ClientId} has been blocked, quota {rule.Limit}/{rule.Period} exceeded by {counter.Count - rule.Limit}. Blocked by rule {rule.Endpoint}, TraceIdentifier {httpContext.TraceIdentifier}. MonitorMode: {rule.MonitorMode}");
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
@@ -23,7 +23,7 @@ namespace AspNetCoreRateLimit
 
         protected override void LogBlockedRequest(HttpContext httpContext, ClientRequestIdentity identity, RateLimitCounter counter, RateLimitRule rule)
         {
-            _logger.LogInformation($"Request {identity.HttpVerb}:{identity.Path} from IP {identity.ClientIp} has been blocked, quota {rule.Limit}/{rule.Period} exceeded by {counter.Count - rule.Limit}. Blocked by rule {rule.Endpoint}, TraceIdentifier {httpContext.TraceIdentifier}.");
+            _logger.LogInformation($"Request {identity.HttpVerb}:{identity.Path} from IP {identity.ClientIp} has been blocked, quota {rule.Limit}/{rule.Period} exceeded by {counter.Count - rule.Limit}. Blocked by rule {rule.Endpoint}, TraceIdentifier {httpContext.TraceIdentifier}. MonitorMode: {rule.MonitorMode}");
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
@@ -77,10 +77,13 @@ namespace AspNetCoreRateLimit
                             await _options.RequestBlockedBehaviorAsync(context, identity, rateLimitCounter, rule);
                         }
 
-                        // break execution
-                        await ReturnQuotaExceededResponse(context, rule, retryAfter);
+                        if (!rule.MonitorMode)
+                        {
+                            // break execution
+                            await ReturnQuotaExceededResponse(context, rule, retryAfter);
 
-                        return;
+                            return;
+                        }
                     }
                 }
                 // if limit is zero or less, block the request.
@@ -94,10 +97,13 @@ namespace AspNetCoreRateLimit
                         await _options.RequestBlockedBehaviorAsync(context, identity, rateLimitCounter, rule);
                     }
 
-                    // break execution (Int32 max used to represent infinity)
-                    await ReturnQuotaExceededResponse(context, rule, int.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                    if (!rule.MonitorMode)
+                    {
+                        // break execution (Int32 max used to represent infinity)
+                        await ReturnQuotaExceededResponse(context, rule, int.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-                    return;
+                        return;
+                    }
                 }
 
                 rulesDict.Add(rule, rateLimitCounter);

--- a/src/AspNetCoreRateLimit/Models/RateLimitRule.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitRule.cs
@@ -30,5 +30,10 @@ namespace AspNetCoreRateLimit
         /// Gets or sets a model that represents the QuotaExceeded response (content-type, content, status code).
         /// </summary>
         public QuotaExceededResponse QuotaExceededResponse { get; set; }
+
+        /// <summary>
+        /// If MonitorMode is true requests that exceed the limit are only logged, and will execute successfully.
+        /// </summary>
+        public bool MonitorMode { get; set; } = false;
     }
 }

--- a/test/AspNetCoreRateLimit.Demo/appsettings.Regex.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.Regex.json
@@ -107,6 +107,17 @@
             "Limit": 0
           }
         ]
+      },
+      {
+        "Ip": "84.247.85.232",
+        "Rules": [
+          {
+            "Endpoint": ".+",
+            "Period": "1m",
+            "Limit": 1,
+            "MonitorMode": true
+          }
+        ]
       }
     ]
   },

--- a/test/AspNetCoreRateLimit.Demo/appsettings.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.json
@@ -114,6 +114,17 @@
             "Limit": 0
           }
         ]
+      },
+      {
+        "Ip": "84.247.85.232",
+        "Rules": [
+          {
+            "Endpoint": "*",
+            "Period": "1m",
+            "Limit": 1,
+            "MonitorMode": true
+          }
+        ]
       }
     ]
   },

--- a/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
+++ b/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
@@ -220,5 +220,27 @@ namespace AspNetCoreRateLimit.Tests
             // Assert
             Assert.Contains(keyword, content);
         }
+
+        [Theory]
+        [InlineData(ClientType.Wildcard, "84.247.85.232")]
+        [InlineData(ClientType.Regex, "84.247.85.232")]
+        public async Task SpecificIpRuleMonitorActive(ClientType clientType, string ip)
+        {
+            // Arrange
+            int responseStatusCode = 0;
+
+            // Act    
+            for (int i = 0; i < 2; i++)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, apiValuesPath);
+                request.Headers.Add("X-Real-IP", ip);
+
+                var response = await GetClient(clientType).SendAsync(request);
+                responseStatusCode = (int)response.StatusCode;
+            }
+
+            // Assert
+            Assert.Equal(200, responseStatusCode);
+        }
     }
 }


### PR DESCRIPTION
In the RateLimitRules you can now set "MonitorMode" to true (default is false).
When set to true exceeding requests won't fail, but they are logged like they have failed.
I think that should also solve #112 