### PR TITLE
updated redis atomic increment script to resolve issue with ttl not being set

### DIFF
--- a/src/AspNetCoreRateLimit.Redis/RedisProcessingStrategy.cs
+++ b/src/AspNetCoreRateLimit.Redis/RedisProcessingStrategy.cs
@@ -20,7 +20,7 @@ namespace AspNetCoreRateLimit.Redis
             _logger = logger;
         }
 
-        static private readonly LuaScript _atomicIncrement = LuaScript.Prepare("local count count = redis.call(\"INCRBYFLOAT\", @key, tonumber(@delta)) if count == @delta then redis.call(\"EXPIRE\", @key, @timeout) end return count");
+        static private readonly LuaScript _atomicIncrement = LuaScript.Prepare("local count = redis.call(\"INCRBYFLOAT\", @key, tonumber(@delta)) local ttl = redis.call(\"TTL\", @key) if ttl == -1 then redis.call(\"EXPIRE\", @key, @timeout) end return count");
 
         public override async Task<RateLimitCounter> ProcessRequestAsync(ClientRequestIdentity requestIdentity, RateLimitRule rule, ICounterKeyBuilder counterKeyBuilder, RateLimitOptions rateLimitOptions, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
This PR attempts to fix https://github.com/stefanprodan/AspNetCoreRateLimit/issues/253

I was unable to get evidence of the root cause. However, I suspect that the existing `if count == @delta` check doesn't match sometimes when it should. My proposed change should always ensure it is set and clean up any ttl currently set as -1.

I considered using NX as per https://redis.io/commands/expire. However, it is only available as of version 7. I'm on Azure Redis which has a max version of 6.