### PR TITLE
Add configurable Redis key prefixes

### DIFF
--- a/src/AspNetCoreRateLimit.Redis/RedisProcessingStrategy.cs
+++ b/src/AspNetCoreRateLimit.Redis/RedisProcessingStrategy.cs
@@ -3,6 +3,7 @@ using StackExchange.Redis;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace AspNetCoreRateLimit.Redis
 {
@@ -10,13 +11,15 @@ namespace AspNetCoreRateLimit.Redis
     {
         private readonly IConnectionMultiplexer _connectionMultiplexer;
         private readonly IRateLimitConfiguration _config;
+        private readonly RedisRateLimitOptions _options;
         private readonly ILogger<RedisProcessingStrategy> _logger;
 
-        public RedisProcessingStrategy(IConnectionMultiplexer connectionMultiplexer, IRateLimitConfiguration config, ILogger<RedisProcessingStrategy> logger)
+        public RedisProcessingStrategy(IConnectionMultiplexer connectionMultiplexer, IRateLimitConfiguration config, IOptions<RedisRateLimitOptions> redisOptions, ILogger<RedisProcessingStrategy> logger)
             : base(config)
         {
             _connectionMultiplexer = connectionMultiplexer ?? throw new ArgumentException("IConnectionMultiplexer was null. Ensure StackExchange.Redis was successfully registered");
             _config = config;
+            _options = redisOptions.Value;
             _logger = logger;
         }
 
@@ -41,6 +44,12 @@ namespace AspNetCoreRateLimit.Redis
                 Count = (double)count,
                 Timestamp = intervalStart
             };
+        }
+
+        protected override string BuildCounterKey(ClientRequestIdentity requestIdentity, RateLimitRule rule, ICounterKeyBuilder counterKeyBuilder,
+            RateLimitOptions rateLimitOptions)
+        {
+            return $"{_options.KeyPrefix}{base.BuildCounterKey(requestIdentity, rule, counterKeyBuilder, rateLimitOptions)}";
         }
     }
 }

--- a/src/AspNetCoreRateLimit.Redis/RedisRateLimitOptions.cs
+++ b/src/AspNetCoreRateLimit.Redis/RedisRateLimitOptions.cs
@@ -1,0 +1,10 @@
+namespace AspNetCoreRateLimit.Redis
+{
+    public class RedisRateLimitOptions
+    {
+        /// <summary>
+        ///     Gets or sets the Redis key prefix
+        /// </summary>
+        public string KeyPrefix { get; set; } = "ratelimits:";
+    }
+}

--- a/test/AspNetCoreRateLimit.Demo/Startup.cs
+++ b/test/AspNetCoreRateLimit.Demo/Startup.cs
@@ -28,11 +28,14 @@ namespace AspNetCoreRateLimit.Demo
             // configure client rate limiting middleware
             services.Configure<ClientRateLimitOptions>(Configuration.GetSection("ClientRateLimiting"));
             services.Configure<ClientRateLimitPolicies>(Configuration.GetSection("ClientRateLimitPolicies"));
+            
+            // configure Redis rate limiting strategy
+            services.Configure<RedisRateLimitOptions>(Configuration.GetSection("RedisRateLimitPolicies"));
 
             // register stores
             services.AddInMemoryRateLimiting();
             //services.AddDistributedRateLimiting<AsyncKeyLockProcessingStrategy>();
-            //services.AddDistributedRateLimiting<RedisProcessingStrategy>();
+            // services.AddDistributedRateLimiting<RedisProcessingStrategy>();
             //services.AddRedisRateLimiting();
 
             services.AddMvc((options) =>

--- a/test/AspNetCoreRateLimit.Demo/Startup.cs
+++ b/test/AspNetCoreRateLimit.Demo/Startup.cs
@@ -34,9 +34,9 @@ namespace AspNetCoreRateLimit.Demo
 
             // register stores
             services.AddInMemoryRateLimiting();
-            //services.AddDistributedRateLimiting<AsyncKeyLockProcessingStrategy>();
+            // services.AddDistributedRateLimiting<AsyncKeyLockProcessingStrategy>();
             // services.AddDistributedRateLimiting<RedisProcessingStrategy>();
-            //services.AddRedisRateLimiting();
+            // services.AddRedisRateLimiting();
 
             services.AddMvc((options) =>
             {

--- a/test/AspNetCoreRateLimit.Demo/appsettings.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.json
@@ -216,5 +216,9 @@
         ]
       }
     ]
+  },
+  
+  "RedisRateLimitPolicies": {
+    "KeyPrefix": "ratelimits:"
   }
 }


### PR DESCRIPTION
Redis keys are conventionally namespaced using colons to avoid naming collisions and improve readability. Additionally, bare keys often make it difficult to view database contents from GUI clients, many of which group and filter keys by namespace.

For those reasons, this pull request introduces  a `RedisRateLimitOptions` class with a `KeyPrefix` property.