### PR TITLE
Use correct prefix for IpCounterKeyBuilder

### DIFF
--- a/src/AspNetCoreRateLimit/CounterKeyBuilders/IpCounterKeyBuilder.cs
+++ b/src/AspNetCoreRateLimit/CounterKeyBuilders/IpCounterKeyBuilder.cs
@@ -11,7 +11,7 @@
 
         public string Build(ClientRequestIdentity requestIdentity, RateLimitRule rule)
         {
-            return $"{_options.RateLimitCounterPrefix}_{requestIdentity.ClientIp}_{rule.Period}";
+            return $"{_options.IpPolicyPrefix}_{requestIdentity.ClientIp}_{rule.Period}";
         }
     }
 }


### PR DESCRIPTION
The IpCounterKeyBuilder is using RateLimitCounterPrefix.  Change it to use the corresponding prefix IpPolicyPrefix.