### PR TITLE
Added an option to avoid interrupting the request pipeline

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
@@ -14,7 +14,7 @@ namespace AspNetCoreRateLimit
             IClientPolicyStore policyStore,
             IRateLimitConfiguration config,
             ILogger<ClientRateLimitMiddleware> logger)
-        : base(next, options?.Value, new ClientRateLimitProcessor(options?.Value, policyStore, processingStrategy), config)
+        : base(next, options?.Value, new ClientRateLimitProcessor(options?.Value, policyStore, processingStrategy), config, logger)
         {
             _logger = logger;
         }

--- a/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
@@ -15,7 +15,7 @@ namespace AspNetCoreRateLimit
             IRateLimitConfiguration config,
             ILogger<IpRateLimitMiddleware> logger
         )
-            : base(next, options?.Value, new IpRateLimitProcessor(options?.Value, policyStore, processingStrategy), config)
+            : base(next, options?.Value, new IpRateLimitProcessor(options?.Value, policyStore, processingStrategy), config, logger)
         {
             _logger = logger;
         }

--- a/src/AspNetCoreRateLimit/Models/RateLimitOptions.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitOptions.cs
@@ -71,5 +71,10 @@ namespace AspNetCoreRateLimit
         /// Gets or sets behavior after the request is blocked
         /// </summary>
         public Func<HttpContext, ClientRequestIdentity, RateLimitCounter, RateLimitRule, Task> RequestBlockedBehaviorAsync { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the behavior that determines whether the request pipeline should be aborted in case of any rate limiting issues (i.e. Redis or SQLServer is not available when used as a distributed counter store).
+        /// </summary>
+        public bool DoNotInterruptRequestPipelineOnFailure { get; set; }
     }
 }


### PR DESCRIPTION
Hello!
We use AspNetCoreRateLimit with Redis (as a distributed counter store). And in this use case, Redis might not be available. This causes the target service to stop servicing the requests (due to exception in RateLimitMiddleware). But it is critical for us to keep serving requests even if there are some rate limiting issues (Redis not available or some other issue).
It would be ideal if there was an option to disable interrupting the request pipeline due to rate limiting issues.
Please consider this PR.