### PR TITLE
only perform ResolveIdentityAsync if any rules apply to requested end…

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
@@ -37,6 +37,14 @@ namespace AspNetCoreRateLimit
                 return;
             }
 
+            var rules = (await _processor.GetMatchingRulesAsync(identity, context.RequestAborted)).ToArray();
+
+            if (!rules.Any())
+            {
+                await _next.Invoke(context);
+                return;
+            }
+
             // compute identity from request
             var identity = await ResolveIdentityAsync(context);
 
@@ -46,8 +54,6 @@ namespace AspNetCoreRateLimit
                 await _next.Invoke(context);
                 return;
             }
-
-            var rules = await _processor.GetMatchingRulesAsync(identity, context.RequestAborted);
 
             var rulesDict = new Dictionary<RateLimitRule, RateLimitCounter>();
 


### PR DESCRIPTION
I want to make sure that the `ResolveIdentityAsync` method only gets called if at least one rule matches the requested endpoint.

If no rule matches the endpoint a custom client or IP resolver could fail because the code within the resolver might be optimized for usage with rate limited endpoints.

Furthermore, it's not a good idea performance-wise to always call the resolving method even if its result is not being used, because no rule matches the endpoint