### PR TITLE
Allow Client or IP rate limiting to be disabled

### DIFF
--- a/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/RateLimitMiddleware.cs
@@ -31,7 +31,7 @@ namespace AspNetCoreRateLimit
         public async Task Invoke(HttpContext context)
         {
             // check if rate limiting is enabled
-            if (_options == null)
+            if (_options == null || _options.RateLimitingEnabled == false)
             {
                 await _next.Invoke(context);
                 return;

--- a/src/AspNetCoreRateLimit/Models/RateLimitOptions.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitOptions.cs
@@ -7,6 +7,11 @@ namespace AspNetCoreRateLimit
 {
     public class RateLimitOptions
     {
+        /// <summary>
+        /// Gets or sets whether Rate Limiting is enabled
+        /// </summary>
+        public bool RateLimitingEnabled { get; set; } = true; // default for backward compatibility
+
         public List<RateLimitRule> GeneralRules { get; set; }
 
         public List<string> EndpointWhitelist { get; set; }

--- a/test/AspNetCoreRateLimit.Demo/appsettings.EnabledFalse.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.EnabledFalse.json
@@ -9,7 +9,8 @@
   },
 
   "IpRateLimiting": {
-    "EnableEndpointRateLimiting": false,
+    "RateLimitingEnabled": false,
+    "EnableEndpointRateLimiting": true,
     "EnableRegexRuleMatching": true,
     "StackBlockedRequests": false,
     "RealIpHeader": "X-Real-IP",
@@ -123,7 +124,8 @@
   },
 
   "ClientRateLimiting": {
-    "EnableEndpointRateLimiting": false,
+    "RateLimitingEnabled": false,
+    "EnableEndpointRateLimiting": true,
     "EnableRegexRuleMatching": true,
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,

--- a/test/AspNetCoreRateLimit.Demo/appsettings.EnabledFalse.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.EnabledFalse.json
@@ -9,13 +9,14 @@
   },
 
   "IpRateLimiting": {
-    "RateLimitingEnabled": true, 
-    "EnableEndpointRateLimiting": true,
+    "EnableEndpointRateLimiting": false,
+    "EnableRegexRuleMatching": true,
     "StackBlockedRequests": false,
     "RealIpHeader": "X-Real-IP",
+    "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
     "IpWhitelist": [ "::1/10", "192.168.0.0/24" ],
-    "EndpointWhitelist": [ "delete:/api/values", "*:/api/clients", "*:/api/ClientRateLimit", "*:/api/IpRateLimit", "get:/" ],
+    "EndpointWhitelist": [ "delete:/api/values", ":/api/clients", ":/api/ClientRateLimit", ":/api/IpRateLimit", "get:/" ],
     "ClientWhitelist": [ "cl-key-1", "cl-key-2" ],
     "QuotaExceededResponse": {
       "Content": "{{ \"message\": \"Whoa! Calm down, cowboy!\", \"details\": \"Quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }}",
@@ -23,23 +24,14 @@
     },
     "GeneralRules": [
       {
-        "Endpoint": "*",
+        "Endpoint": ".+",
         "Period": "1s",
         "Limit": 2
       },
       {
-        "Endpoint": "*",
+        "Endpoint": ".+",
         "Period": "1m",
         "Limit": 5
-      },
-      {
-        "Endpoint": "get:/api/user/get-all",
-        "Period": "1m",
-        "Limit": 6,
-        "QuotaExceededResponse": {
-          "Content": "{{ \"data\": [], \"error\": \"Get all user api interface  quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }}",
-          "ContentType": "application/json"
-        }
       }
     ]
   },
@@ -50,12 +42,12 @@
         "Ip": "84.247.85.224",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1s",
             "Limit": 10
           },
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1m",
             "Limit": 2
           },
@@ -70,17 +62,17 @@
         "Ip": "84.247.85.225",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1s",
             "Limit": 10
           },
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1m",
             "Limit": 5
           },
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1h",
             "Limit": 2
           }
@@ -90,17 +82,17 @@
         "Ip": "84.247.85.226",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1s",
             "Limit": 10
           },
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1m",
             "Limit": 5
           },
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1d",
             "Limit": 2
           }
@@ -110,7 +102,7 @@
         "Ip": "84.247.85.231",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1m",
             "Limit": 0
           }
@@ -120,7 +112,7 @@
         "Ip": "84.247.85.232",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1m",
             "Limit": 1,
             "MonitorMode": true
@@ -131,20 +123,20 @@
   },
 
   "ClientRateLimiting": {
-    "RateLimitingEnabled": true,
-    "EnableEndpointRateLimiting": true,
+    "EnableEndpointRateLimiting": false,
+    "EnableRegexRuleMatching": true,
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
-    "EndpointWhitelist": [ "*:/api/values", "delete:/api/clients", "get:/" ],
+    "EndpointWhitelist": [ "((post)|(put)|(get)|(delete)):/api/values", "delete:/api/clients" ],
     "ClientWhitelist": [ "cl-key-a", "cl-key-b" ],
     "GeneralRules": [
       {
-        "Endpoint": "*",
+        "Endpoint": ".+",
         "Period": "1s",
         "Limit": 2
       },
       {
-        "Endpoint": "*",
+        "Endpoint": ".+",
         "Period": "1m",
         "Limit": 5
       },
@@ -152,15 +144,6 @@
         "Endpoint": "post:/api/clients",
         "Period": "5m",
         "Limit": 3
-      },
-      {
-        "Endpoint": "get:/api/user/get-info",
-        "Period": "1m",
-        "Limit": 3,
-        "QuotaExceededResponse": {
-          "Content": "{{ \"name\": \"\" , \"error\": \"Get user information api interface  quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }}",
-          "ContentType": "application/json"
-        }
       }
     ]
   },
@@ -171,7 +154,7 @@
         "ClientId": "cl-key-1",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1s",
             "Limit": 10
           },
@@ -191,7 +174,7 @@
         "ClientId": "cl-key-2",
         "Rules": [
           {
-            "Endpoint": "*",
+            "Endpoint": ".+",
             "Period": "1s",
             "Limit": 10
           },

--- a/test/AspNetCoreRateLimit.Demo/appsettings.Regex.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.Regex.json
@@ -9,6 +9,7 @@
   },
 
   "IpRateLimiting": {
+    "RateLimitingEnabled": true,
     "EnableEndpointRateLimiting": true,
     "EnableRegexRuleMatching": true,
     "StackBlockedRequests": false,
@@ -123,6 +124,7 @@
   },
 
   "ClientRateLimiting": {
+    "RateLimitingEnabled": true,
     "EnableEndpointRateLimiting": true,
     "EnableRegexRuleMatching": true,
     "ClientIdHeader": "X-ClientId",

--- a/test/AspNetCoreRateLimit.Tests/BaseClassFixture.cs
+++ b/test/AspNetCoreRateLimit.Tests/BaseClassFixture.cs
@@ -11,6 +11,7 @@ namespace AspNetCoreRateLimit.Tests
     {
         private readonly HttpClient _wildcardClient;
         private readonly HttpClient _regexClient;
+        private readonly HttpClient _enabledFalseClient;
 
         protected BaseClassFixture(RateLimitWebApplicationFactory factory)
         {
@@ -29,6 +30,18 @@ namespace AspNetCoreRateLimit.Tests
             {
                 BaseAddress = new System.Uri("https://localhost:44304")
             });
+
+            _enabledFalseClient = factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((context, conf) =>
+                {
+                    conf.AddJsonFile("appsettings.EnabledFalse.json");
+                });
+            }).CreateClient(options: new WebApplicationFactoryClientOptions
+            {
+                BaseAddress = new System.Uri("https://localhost:44304"),
+                
+            });
         }
 
         /// <summary>
@@ -43,9 +56,16 @@ namespace AspNetCoreRateLimit.Tests
                     return _wildcardClient;
                 case ClientType.Regex:
                     return _regexClient;
+                case ClientType.EnabledFalse:
+                    return _enabledFalseClient;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(clientType), clientType, "Unexpected client type.");
             }
+        }
+
+        protected void SetOptions(RateLimitOptions options)
+        {
+
         }
     }
 }

--- a/test/AspNetCoreRateLimit.Tests/ClientRateLimitTests.cs
+++ b/test/AspNetCoreRateLimit.Tests/ClientRateLimitTests.cs
@@ -1,5 +1,6 @@
 ﻿using AspNetCoreRateLimit.Tests.Enums;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -223,6 +224,30 @@ namespace AspNetCoreRateLimit.Tests
 
             // Assert
             Assert.Contains(keyword, content);
+        }
+
+        [Theory]
+        [InlineData(ClientType.EnabledFalse)]
+        public async Task RulesDisabled(ClientType clientType)
+        {
+            // Arrange
+            var clientId = "cl-key-3";
+            int responseStatusCode = 0;
+
+            // Act    
+            for (int i = 0; i < 4; i++)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, apiPath);
+                request.Headers.Add("X-ClientId", clientId);
+                request.Headers.Add("X-Real-IP", ip);
+                request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+                var response = await GetClient(clientType).SendAsync(request);
+                responseStatusCode = (int)response.StatusCode;
+            }
+
+            // Assert
+            Assert.Equal(200, responseStatusCode);
         }
     }
 }

--- a/test/AspNetCoreRateLimit.Tests/Enums/ClientType.cs
+++ b/test/AspNetCoreRateLimit.Tests/Enums/ClientType.cs
@@ -3,6 +3,7 @@
     public enum ClientType
     {
         Wildcard,
-        Regex
+        Regex,
+        EnabledFalse
     }
 }

--- a/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
+++ b/test/AspNetCoreRateLimit.Tests/IpRateLimitTests.cs
@@ -1,5 +1,6 @@
 ﻿using AspNetCoreRateLimit.Tests.Enums;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -265,5 +266,28 @@ namespace AspNetCoreRateLimit.Tests
             // Assert
             Assert.Equal(200, responseStatusCode);
         }
+
+        [Theory]
+        [InlineData(ClientType.EnabledFalse, "84.247.85.232")]
+        public async Task RulesDisabled(ClientType clientType, string ip)
+        {
+            // Arrange
+            int responseStatusCode = 0;
+
+            // Act    
+            for (int i = 0; i < 2; i++)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, apiValuesPath);
+                request.Headers.Add("X-Real-IP", ip);
+                request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+                var response = await GetClient(clientType).SendAsync(request);
+                responseStatusCode = (int)response.StatusCode;
+            }
+
+            // Assert
+            Assert.Equal(200, responseStatusCode);
+        }
+
     }
 }


### PR DESCRIPTION
This change allows rate limiting to be disabled and re-enabled without removing configuration options

Currently,  to disable rate limiting, the entire configuration/options section has to be removed from appsettings.json
