### PR TITLE
Handled exceptions to complete serving request received

### DIFF
--- a/src/AspNetCoreRateLimit.Redis/RedisProcessingStrategy.cs
+++ b/src/AspNetCoreRateLimit.Redis/RedisProcessingStrategy.cs
@@ -36,12 +36,24 @@ namespace AspNetCoreRateLimit.Redis
             var intervalStart = new DateTime(numberOfIntervals * interval.Ticks, DateTimeKind.Utc);
 
             _logger.LogDebug("Calling Lua script. {counterId}, {timeout}, {delta}", counterId, interval.TotalSeconds, 1D);
-            var count = await _connectionMultiplexer.GetDatabase().ScriptEvaluateAsync(_atomicIncrement, new { key = new RedisKey(counterId), timeout = interval.TotalSeconds, delta = RateIncrementer?.Invoke() ?? 1D });
-            return new RateLimitCounter
+            try
             {
-                Count = (double)count,
-                Timestamp = intervalStart
-            };
+                var count = await _connectionMultiplexer.GetDatabase().ScriptEvaluateAsync(_atomicIncrement, new { key = new RedisKey(counterId), timeout = interval.TotalSeconds, delta = RateIncrementer?.Invoke() ?? 1D });
+                return new RateLimitCounter
+                {
+                    Count = (double)count,
+                    Timestamp = intervalStart
+                };
+            }
+            catch (Exception ex) when (ex is RedisException || ex is RedisCommandException || ex is RedisTimeoutException)
+            {
+                _logger.LogWarning($"Error occurred: {ex.Message}");
+                return new RateLimitCounter
+                {
+                    Count = 0,
+                    Timestamp = intervalStart
+                };
+            }
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheClientPolicyStore.cs
+++ b/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheClientPolicyStore.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace AspNetCoreRateLimit
@@ -8,11 +9,12 @@ namespace AspNetCoreRateLimit
     {
         private readonly ClientRateLimitOptions _options;
         private readonly ClientRateLimitPolicies _policies;
-
+        private readonly ILogger<DistributedCacheClientPolicyStore> _logger;
         public DistributedCacheClientPolicyStore(
             IDistributedCache cache,
+            ILogger<DistributedCacheClientPolicyStore> logger,
             IOptions<ClientRateLimitOptions> options = null,
-            IOptions<ClientRateLimitPolicies> policies = null) : base(cache)
+            IOptions<ClientRateLimitPolicies> policies = null) : base(cache,logger)
         {
             _options = options?.Value;
             _policies = policies?.Value;

--- a/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheIpPolicyStore.cs
+++ b/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheIpPolicyStore.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace AspNetCoreRateLimit
@@ -8,11 +9,12 @@ namespace AspNetCoreRateLimit
     {
         private readonly IpRateLimitOptions _options;
         private readonly IpRateLimitPolicies _policies;
-
+        private readonly ILogger<DistributedCacheIpPolicyStore> _logger;
         public DistributedCacheIpPolicyStore(
             IDistributedCache cache,
+            ILogger<DistributedCacheIpPolicyStore> logger,
             IOptions<IpRateLimitOptions> options = null,
-            IOptions<IpRateLimitPolicies> policies = null) : base(cache)
+            IOptions<IpRateLimitPolicies> policies = null) : base(cache, logger)
         {
             _options = options?.Value;
             _policies = policies?.Value;

--- a/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheRateLimitCounterStore.cs
+++ b/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheRateLimitCounterStore.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 
 namespace AspNetCoreRateLimit
 {
     public class DistributedCacheRateLimitCounterStore : DistributedCacheRateLimitStore<RateLimitCounter?>, IRateLimitCounterStore
     {
-        public DistributedCacheRateLimitCounterStore(IDistributedCache cache) : base(cache)
+        public DistributedCacheRateLimitCounterStore(IDistributedCache cache,ILogger<DistributedCacheRateLimitCounterStore> logger) : base(cache,logger)
         {
         }
     }

--- a/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheRateLimitStore.cs
+++ b/src/AspNetCoreRateLimit/Store/DistributedCache/DistributedCacheRateLimitStore.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Threading;
@@ -9,10 +10,12 @@ namespace AspNetCoreRateLimit
     public class DistributedCacheRateLimitStore<T> : IRateLimitStore<T>
     {
         private readonly IDistributedCache _cache;
+        private readonly ILogger<DistributedCacheRateLimitStore<T>> _logger;
 
-        public DistributedCacheRateLimitStore(IDistributedCache cache)
+        public DistributedCacheRateLimitStore(IDistributedCache cache, ILogger<DistributedCacheRateLimitStore<T>> logger)
         {
             _cache = cache;
+            _logger = logger;
         }
 
         public Task SetAsync(string id, T entry, TimeSpan? expirationTime = null, CancellationToken cancellationToken = default)
@@ -23,32 +26,60 @@ namespace AspNetCoreRateLimit
             {
                 options.SetAbsoluteExpiration(expirationTime.Value);
             }
-
-            return _cache.SetStringAsync(id, JsonConvert.SerializeObject(entry), options, cancellationToken);
+            try
+            {
+                return _cache.SetStringAsync(id, JsonConvert.SerializeObject(entry), options, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Error occurred: {ex.Message}");
+                return Task.CompletedTask;
+            }
         }
 
         public async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken = default)
         {
-            var stored = await _cache.GetStringAsync(id, cancellationToken);
-
-            return !string.IsNullOrEmpty(stored);
+            try
+            {
+                var stored = await _cache.GetStringAsync(id, cancellationToken);
+                return !string.IsNullOrEmpty(stored);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Error occurred: {ex.Message}");
+                return true;
+            }
         }
 
         public async Task<T> GetAsync(string id, CancellationToken cancellationToken = default)
         {
-            var stored = await _cache.GetStringAsync(id, cancellationToken);
-
-            if (!string.IsNullOrEmpty(stored))
+            try
             {
-                return JsonConvert.DeserializeObject<T>(stored);
-            }
+                var stored = await _cache.GetStringAsync(id, cancellationToken);
 
+                if (!string.IsNullOrEmpty(stored))
+                {
+                    return JsonConvert.DeserializeObject<T>(stored);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Error occurred: {ex.Message}");
+            }
             return default;
         }
 
         public Task RemoveAsync(string id, CancellationToken cancellationToken = default)
         {
-            return _cache.RemoveAsync(id, cancellationToken);
+            try
+            {
+                return _cache.RemoveAsync(id, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Error occurred: {ex.Message}");
+                return default;
+            }
         }
     }
 }


### PR DESCRIPTION
When using Redis as counter storage, the API began returning 500 errors when Redis went down or its memory became full. To handle this scenario, we've added exception handling so the API can function as expected without rate limiting. 
Could you please review and merge this? Feel free to leave a comment if any changes are needed.