### PR TITLE
Add three kinds of limit counter mode, and two kinds of response mode for quota exceeded response.

### DIFF
--- a/src/AspNetCoreRateLimit/CounterKeyBuilders/PathCounterKeyBuilder.cs
+++ b/src/AspNetCoreRateLimit/CounterKeyBuilders/PathCounterKeyBuilder.cs
@@ -4,7 +4,16 @@
     {
         public string Build(ClientRequestIdentity requestIdentity, RateLimitRule rule)
         {
-            return $"_{requestIdentity.HttpVerb}_{requestIdentity.Path}";
+            switch (rule.ConterKeyMode) {
+                case EPConterKeyMode.VerbAndPath:
+                    return $"_VP_{requestIdentity.HttpVerb}_{requestIdentity.Path}";
+                case EPConterKeyMode.Path:
+                    return $"_P_{requestIdentity.Path}";
+                case EPConterKeyMode.VerbAndRule:
+                    return $"_VE_{requestIdentity.HttpVerb}_{rule.Endpoint}";
+                default:
+                    return $"_E_{rule.Endpoint}";
+            }
         }
     }
 }

--- a/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/ClientRateLimitMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -13,8 +14,9 @@ namespace AspNetCoreRateLimit
             IOptions<ClientRateLimitOptions> options,
             IClientPolicyStore policyStore,
             IRateLimitConfiguration config,
-            ILogger<ClientRateLimitMiddleware> logger)
-        : base(next, options?.Value, new ClientRateLimitProcessor(options?.Value, policyStore, processingStrategy), config)
+            ILogger<ClientRateLimitMiddleware> logger,
+            LinkGenerator linkGenerator)
+        : base(next, options?.Value, new ClientRateLimitProcessor(options?.Value, policyStore, processingStrategy), config, linkGenerator)
         {
             _logger = logger;
         }

--- a/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
+++ b/src/AspNetCoreRateLimit/Middleware/IpRateLimitMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -13,9 +14,10 @@ namespace AspNetCoreRateLimit
             IOptions<IpRateLimitOptions> options,
             IIpPolicyStore policyStore,
             IRateLimitConfiguration config,
-            ILogger<IpRateLimitMiddleware> logger
+            ILogger<IpRateLimitMiddleware> logger,
+            LinkGenerator linkGenerator
         )
-            : base(next, options?.Value, new IpRateLimitProcessor(options?.Value, policyStore, processingStrategy), config)
+            : base(next, options?.Value, new IpRateLimitProcessor(options?.Value, policyStore, processingStrategy), config, linkGenerator)
         {
             _logger = logger;
         }

--- a/src/AspNetCoreRateLimit/Models/QuotaExceededParams.cs
+++ b/src/AspNetCoreRateLimit/Models/QuotaExceededParams.cs
@@ -1,0 +1,33 @@
+﻿namespace AspNetCoreRateLimit.Models
+{
+    /// <summary>
+    /// The parameters for the Quota Exceeded response
+    /// </summary>
+    public class QuotaExceededParams
+    {
+        /// <summary>
+        /// The endpoint that was hit
+        /// </summary>
+        public string EndPoint { get; set; }
+
+        /// <summary>
+        /// quota exceeded path
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// The max limit that was set
+        /// </summary>
+        public double Limit { get; set; }
+
+        /// <summary>
+        /// The period that the limit was set for
+        /// </summary>
+        public string Period { get; set; }
+
+        /// <summary>
+        /// The retry after time
+        /// </summary>
+        public string RetryAfter { get; set; }
+    }
+}

--- a/src/AspNetCoreRateLimit/Models/QuotaExceededResponse.cs
+++ b/src/AspNetCoreRateLimit/Models/QuotaExceededResponse.cs
@@ -6,6 +6,27 @@
 
         public string Content { get; set; }
 
-        public int? StatusCode { get; set; } = 429;
+        public int? StatusCode { get; set; }
+
+        public string Url { get; set; }
+
+        public string Controller { get; set; }
+
+        public string Action { get; set; }
+
+        public ResponseType ResponseType { get; set; }
+
+        public QuotaExceededResponse()
+        {
+            StatusCode = 429;
+            ResponseType = ResponseType.WriteContent;
+        }
+    }
+
+    public enum ResponseType
+    {
+        WriteContent,
+        RedirectToAction,
+        RedirectToUrl
     }
 }

--- a/src/AspNetCoreRateLimit/Models/RateLimitRule.cs
+++ b/src/AspNetCoreRateLimit/Models/RateLimitRule.cs
@@ -15,6 +15,11 @@ namespace AspNetCoreRateLimit
         public string Endpoint { get; set; }
 
         /// <summary>
+        /// A pattern used to identify the uniqueness of an endpoint
+        /// </summary>
+        public EPConterKeyMode ConterKeyMode { get; set; } = EPConterKeyMode.VerbAndPath;
+
+        /// <summary>
         /// Rate limit period as in 1s, 1m, 1h
         /// </summary>
         public string Period { get; set; }
@@ -35,5 +40,36 @@ namespace AspNetCoreRateLimit
         /// If MonitorMode is true requests that exceed the limit are only logged, and will execute successfully.
         /// </summary>
         public bool MonitorMode { get; set; } = false;
+    }
+
+    /// <summary>
+    /// A pattern used to identify the uniqueness of an endpoint.
+    /// </summary>
+    public enum EPConterKeyMode
+    {
+        /// <summary>
+        /// rate limit is applied to the combination of HTTP verb and path. <br/>
+        /// if endpoint is *:/api/values. <br/>
+        /// e.g. GET:/api/values/1 and POST:/api/values/1, GET:/api/values/2 and POST:/api/values/2 will be counted separately.
+        /// </summary>
+        VerbAndPath,
+        /// <summary>
+        /// Path - rate limit is applied to the combination of  path. <br/>
+        /// if endpoint is *:/api/values. <br/>
+        /// GET:/api/values and POST:/api/values will be counted together.
+        /// </summary>
+        Path,
+        /// <summary>
+        /// rate limit is applied to the combination of HTTP verb and rule. <br/>
+        /// if endpoint is *:/api/values. <br/>
+        ///GET:/api/values/1 POST:/api/values/2 will be counted separately. but GET:/api/values/1 and GET:/api/values/2 will be counted together.
+        /// </summary>
+        VerbAndRule,
+        /// <summary>
+        /// rate limit is applied to the combination of rule.<br/>
+        /// if endpoint is *:/api/values. <br/>
+        /// GET:/api/values/1 , POST:/api/values/1, GET:/api/values/2 and POST:/api/values/2 will be counted together.
+        /// </summary>
+        Rule
     }
 }

--- a/test/AspNetCoreRateLimit.Demo/Controllers/CounterKeyController.cs
+++ b/test/AspNetCoreRateLimit.Demo/Controllers/CounterKeyController.cs
@@ -1,0 +1,53 @@
+﻿using AspNetCoreRateLimit.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
+
+namespace AspNetCoreRateLimit.Demo.Controllers
+{
+    [Route("api/[controller]")]
+    public class CounterKeyController : Controller
+    {
+        [HttpGet, HttpPost, HttpOptions, HttpDelete, HttpPut, HttpPatch]
+        [Route("VerbAndPath")]
+        public string VerbAndPath()
+        {
+            return Request.Method;
+        }
+
+        [HttpGet, HttpPost, HttpOptions, HttpDelete, HttpPut, HttpPatch]
+        [Route("Path")]
+        public string Path()
+        {
+            return Request.Method;
+        }
+
+        [HttpGet, HttpPost, HttpOptions, HttpDelete, HttpPut, HttpPatch]
+        [Route("VerbAndRule/{id:int}")]
+        public string VerbAndRule(int id)
+        {
+            return $"{Request.Method}_{id}";
+        }
+
+        [HttpGet, HttpPost, HttpOptions, HttpDelete, HttpPut, HttpPatch]
+        [Route("Rule/{id:int}")]
+        public string Rule(int id)
+        {
+            return $"{Request.Method}_{id}";
+        }
+
+        [HttpGet]
+        [Route("TestCustomQuotaExceededResponse")]
+        public string TestCustomQuotaExceededResponse()
+        {
+            return Request.Method;
+        }
+
+        [HttpGet]
+        [Route("CustomQuotaExceededResponse")]
+        public string CustomQuotaExceededResponse(QuotaExceededParams quotaExceededParams)
+        {
+            Response.StatusCode = 429;
+            return $"This is customQuotaExceededResponse.\r\n{(quotaExceededParams == null ? string.Empty:JsonSerializer.Serialize(quotaExceededParams))}";
+        }
+    }
+}

--- a/test/AspNetCoreRateLimit.Demo/Controllers/ValuesController.cs
+++ b/test/AspNetCoreRateLimit.Demo/Controllers/ValuesController.cs
@@ -37,5 +37,7 @@ namespace AspNetCoreRateLimit.Demo.Controllers
         public void Delete(int id)
         {
         }
+
+
     }
 }

--- a/test/AspNetCoreRateLimit.Demo/Startup.cs
+++ b/test/AspNetCoreRateLimit.Demo/Startup.cs
@@ -48,6 +48,7 @@ namespace AspNetCoreRateLimit.Demo
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.UseRouting();
             app.UseBlockingDetection();
 
             app.UseIpRateLimiting();
@@ -63,7 +64,7 @@ namespace AspNetCoreRateLimit.Demo
                 app.UseHsts();
             }
 
-            app.UseHttpsRedirection();
+            //app.UseHttpsRedirection();
 
             app.UseDefaultFiles(new DefaultFilesOptions 
             { 
@@ -72,6 +73,11 @@ namespace AspNetCoreRateLimit.Demo
             app.UseStaticFiles();
 
             app.UseMvc();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapDefaultControllerRoute();
+            });
         }
     }
 }

--- a/test/AspNetCoreRateLimit.Demo/appsettings.json
+++ b/test/AspNetCoreRateLimit.Demo/appsettings.json
@@ -14,7 +14,7 @@
     "RealIpHeader": "X-Real-IP",
     "HttpStatusCode": 429,
     "IpWhitelist": [ "::1/10", "192.168.0.0/24" ],
-    "EndpointWhitelist": [ "delete:/api/values", "*:/api/clients", "*:/api/ClientRateLimit", "*:/api/IpRateLimit", "get:/" ],
+    "EndpointWhitelist": [ "delete:/api/values", "*:/CounterKey/CustomQuotaExceededResponse", "*:/api/clients", "*:/api/ClientRateLimit", "*:/api/IpRateLimit", "get:/" ],
     "ClientWhitelist": [ "cl-key-1", "cl-key-2" ],
     "QuotaExceededResponse": {
       "Content": "{{ \"message\": \"Whoa! Calm down, cowboy!\", \"details\": \"Quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }}",
@@ -22,12 +22,12 @@
     },
     "GeneralRules": [
       {
-        "Endpoint": "*",
+        "Endpoint": "*:/api/values",
         "Period": "1s",
         "Limit": 2
       },
       {
-        "Endpoint": "*",
+        "Endpoint": "*:/api/values",
         "Period": "1m",
         "Limit": 5
       },
@@ -38,6 +38,41 @@
         "QuotaExceededResponse": {
           "Content": "{{ \"data\": [], \"error\": \"Get all user api interface  quota exceeded. Maximum allowed: {0} per {1}. Please try again in {2} second(s).\" }}",
           "ContentType": "application/json"
+        }
+      },
+      {
+        "Endpoint": "*:/api/CounterKey/VerbAndPath",
+        "Period": "1m",
+        "ConterKeyMode": "VerbAndPath",
+        "Limit": 3
+      },
+      {
+        "Endpoint": "*:/api/CounterKey/Path",
+        "Period": "1m",
+        "ConterKeyMode": "Path",
+        "Limit": 3
+      },
+      {
+        "Endpoint": "*:/api/CounterKey/VerbAndRule/*",
+        "Period": "1m",
+        "ConterKeyMode": "VerbAndRule",
+        "Limit": 3
+      },
+      {
+        "Endpoint": "*:/api/CounterKey/Rule",
+        "Period": "1m",
+        "ConterKeyMode": "Rule",
+        "Limit": 3
+      },
+      {
+        "Endpoint": "*:/api/CounterKey/TestCustomQuotaExceededResponse",
+        "Period": "1m",
+        "ConterKeyMode": "Path",
+        "Limit": 3,
+        "QuotaExceededResponse": {
+          "ResponseType": "RedirectToAction",
+          "Controller": "CounterKey",
+          "Action": "CustomQuotaExceededResponse"
         }
       }
     ]
@@ -133,7 +168,7 @@
     "EnableEndpointRateLimiting": true,
     "ClientIdHeader": "X-ClientId",
     "HttpStatusCode": 429,
-    "EndpointWhitelist": [ "*:/api/values", "delete:/api/clients", "get:/" ],
+    "EndpointWhitelist": [ "*:/api/values", "*:/api/counterkey/*", "delete:/api/clients", "get:/" ],
     "ClientWhitelist": [ "cl-key-a", "cl-key-b" ],
     "GeneralRules": [
       {


### PR DESCRIPTION
1.RateLimitRule adds the ConterKeyMode property. Below is the effect of its value.
Let's say the EndPoint is set to *:/api/values
VerbAndPath (default, compatible with older versions) - GET:/api/values/1 and POST:/api/values/1, GET:/api/values/2 and POST:/api/values/2 will be counted separately.
Path-GET :/api/values and POST:/api/values will be combined and counted
VerbAndRule-GET :/api/values/1 POST:/api/values/2 will be counted separately, but GET:/api/values/1 and GET:/api/values/2 will be counted together.
Rule-GET :/api/values/1, POST:/api/values/1, GET:/api/values/2, POST:/api/values/2 will all be concatenated.
2. Increase ResponseType QuotaExceededResponse, Controller, Action, Url attribute. Depending on the value of ResponseType, different properties are used to respond to different outputs.
WriteContent (default, older compatible) - StatusCode writes Content to the response stream based on ContentType.
RedirectToAction (must set IApplicationBuilder UseRouting(), IApplicationBuilder. UseEndpoints() first) - redirects to the specified Controller. The Action. QuotaExceededParams quotaExceededParams can be obtained from the parameters to output the results with a more customized response.
RedirectToUrl - Redirects to the specified Url. Low custom response, cannot get QuotaExceededParams quotaExceededParams. Suitable for developers who just need to beautification their pages.
3. Add relevant unit tests.
